### PR TITLE
Fix gems configuration on cross-compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,15 @@ end
 ### Cross Compile with MRUBY_CROSS_OS Env
 #### for linux
 ```
-rake MRUBY_CROSS_OS=linux
+rake crosscompile MRUBY_CROSS_OS=linux
 ```
 #### for osx
 ```
-rake MRUBY_CROSS_OS=osx
+rake crosscompile MRUBY_CROSS_OS=osx
 ```
 #### for win32
 ```
-rake MRUBY_CROSS_OS=win32
+rake crosscompile MRUBY_CROSS_OS=win32
 ```
 
 then, generate mruby binaries into `mruby/build/{linux,osx,win32}/`
@@ -38,4 +38,3 @@ then, generate mruby binaries into `mruby/build/{linux,osx,win32}/`
 under the MIT License:
 
 * http://www.opensource.org/licenses/mit-license.php
-

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -56,11 +56,13 @@ if ENV['MRUBY_CROSS_OS'] == "win32"
   end
 end
 
-desc "run all task with crosscompile"
-task :crosscompile do
-  conf = MRuby.targets[ENV["MRUBY_CROSS_OS"]]
-  MRuby.targets["host"].gems.each do |gem|
-    conf.gems << gem
+if ENV["MRUBY_CROSS_OS"]
+  desc "run all task with crosscompile"
+  task :crosscompile do
+    conf = MRuby.targets[ENV["MRUBY_CROSS_OS"]]
+    MRuby.targets["host"].gems.each do |gem|
+      conf.gems << gem
+    end
+    Rake::Task["all"].invoke
   end
-  Rake::Task["all"].invoke
 end

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -56,19 +56,11 @@ if ENV['MRUBY_CROSS_OS'] == "win32"
   end
 end
 
-namespace :cross do
-  def prepare_crosscompile
-    conf = MRuby.targets[ENV["MRUBY_CROSS_OS"]]
-    MRuby.targets["host"].gems.each do |gem|
-      conf.gems << gem
-    end
+desc "run all task with crosscompile"
+task :crosscompile do
+  conf = MRuby.targets[ENV["MRUBY_CROSS_OS"]]
+  MRuby.targets["host"].gems.each do |gem|
+    conf.gems << gem
   end
-
-  %w(all test).each do |t|
-    desc "run #{t} task with crosscompile"
-    task t.to_sym do
-      prepare_crosscompile
-      Rake::Task[t].invoke
-    end
-  end
+  Rake::Task["all"].invoke
 end

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -5,26 +5,11 @@ MRuby::Gem::Specification.new('mruby-cross-compile-on-mac-osx') do |spec|
   spec.summary = 'Cross compiled osx, linux, or win32 binary on Max OSX'
 end
 
-# get mrbgems from build_config.rb
-def get_mrbgems
-  mrbgems = []
-  MRuby.each_target do |target|
-    @gems.map do |gem|
-      mrbgems << gem.dir
-    end
-  end
-  mrbgems
-end
-
 # for OSX
 if ENV['MRUBY_CROSS_OS'] == "osx"
   MRuby::CrossBuild.new('osx') do |conf|
 
     toolchain :gcc
-
-    get_mrbgems.each do |mrbgem|
-      conf.gem mrbgem
-    end
 
   end
 end
@@ -41,10 +26,6 @@ if ENV['MRUBY_CROSS_OS'] == "linux"
 
     fail "Can't find #{cgcc}. Please download compiler from #{url}" unless File.exist? cgcc
     fail "Can't find #{car}. Please download compiler from #{url}" unless File.exist? car
-
-    get_mrbgems.each do |mrbgem|
-      conf.gem mrbgem
-    end
 
     conf.cc.command = cgcc
     conf.cc.flags << "-static"
@@ -66,10 +47,6 @@ if ENV['MRUBY_CROSS_OS'] == "win32"
 
     fail "Can't find #{cgcc}. Please download compiler from #{url}" unless File.exist? cgcc
     fail "Can't find #{car}. Please download compiler from #{url}" unless File.exist? car
-
-    get_mrbgems.each do |mrbgem|
-      conf.gem mrbgem
-    end
 
     conf.cc.command = cgcc
     conf.linker.command = cgcc

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -79,3 +79,19 @@ if ENV['MRUBY_CROSS_OS'] == "win32"
   end
 end
 
+namespace :cross do
+  def prepare_crosscompile
+    conf = MRuby.targets[ENV["MRUBY_CROSS_OS"]]
+    MRuby.targets["host"].gems.each do |gem|
+      conf.gems << gem
+    end
+  end
+
+  %w(all test).each do |t|
+    desc "run #{t} task with crosscompile"
+    task t.to_sym do
+      prepare_crosscompile
+      Rake::Task[t].invoke
+    end
+  end
+end


### PR DESCRIPTION
I found that host's gems configuration can't be assignment to cross-compile configuration.

It caused by mrbrake architecture. If we run rake command, we can get following results.
1. build task with Rake try to load mrbgem.rake including cross-compile configuration at first.
2. Rakefile evaluates build_config.rb configuration.
3. Invoke target task on Rakefile. There is no gems at cross-compile configuration.

I added new task for assignment host's gems into cross-compile configuration.
